### PR TITLE
pass process URL prefix as an ENV VAR

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -68,8 +68,7 @@ const {
 
 app.use(function(req, res, next) {
   // had to rewrite the path to get it playing nice with a not-root resource in api gateway
-  req.url = req.url.replace('/uhw', '');
-  req.url = req.url.replace('/hncomino', '');
+  req.url = req.url.replace(`/${process.env.URL_PREFIX}`, '');
   next();
 });
 
@@ -112,7 +111,12 @@ app.get('/documents/:id/view', async (req, res) => {
       res.set('Content-Type', converted.mimeType);
       res.send(converted.doc);
     } else {
-      res.send(downloadTemplate({ id: req.params.id }));
+      res.send(
+        downloadTemplate({
+          id: req.params.id,
+          system: process.env.URL_PREFIX
+        })
+      );
     }
   } catch (err) {
     console.log(err);

--- a/api/lib/templates/download.html.hbs
+++ b/api/lib/templates/download.html.hbs
@@ -1,5 +1,8 @@
 <html>
-  <body>
-    <p>This document is not able to display in your browser. <a href="/documents/{{id}}/download">Download it here</a></p>
-  </body>
+
+<body>
+  <p>This document is not able to display in your browser. <a href="/{{system}}/documents/{{id}}/download">Download it
+      here</a></p>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "serverless-offline-ssm": "^4.1.2"
   },
   "scripts": {
-    "start": "sls offline start -s dev --noAuth",
-    "debug": "export SLS_DEBUG=* && node --inspect /usr/local/bin/serverless offline -s dev --noAuth",
+    "start": "sls offline start -s dev --noAuth --port 3002",
+    "debug": "export SLS_DEBUG=* && node --inspect /usr/local/bin/serverless offline -s dev --noAuth --port 3002",
     "auth": "serverless invoke local -s dev -f w2-document-api-authorizer -p authorizer/event.json"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,7 @@ functions:
             origins:
               - '*'
     environment:
+      URL_PREFIX: 'uhw'
       S3_BUCKET_NAME: ${ssm:/uhw-document-api/production/S3_BUCKET_NAME}
       W2_DB_URL: ${ssm:/uhw-document-api/production/W2_DB_URL}
       W2_IMAGE_SERVER_URL: ${ssm:/uhw-document-api/production/W2_IMAGE_SERVER_URL}
@@ -68,6 +69,7 @@ functions:
             origins:
               - '*'
     environment:
+      URL_PREFIX: 'hncomino'
       S3_BUCKET_NAME: ${ssm:/hncomino-document-api/production/S3_BUCKET_NAME}
       W2_DB_URL: ${ssm:/hncomino-document-api/production/W2_DB_URL}
       W2_IMAGE_SERVER_URL: ${ssm:/hncomino-document-api/production/W2_IMAGE_SERVER_URL}


### PR DESCRIPTION
There was an error when downloading documents from Comino. The problem was an incorrect url. Url prefix is now stored in an env var as it changes depending on the process.  

![Uploading image.png…]()

