### PR TITLE
Add check for documents

### DIFF
--- a/api/lib/use-cases/GetConvertedDocument.js
+++ b/api/lib/use-cases/GetConvertedDocument.js
@@ -10,7 +10,7 @@ module.exports = function(options) {
       await cacheGateway.put(metadata.id, document);
     }
 
-    if (document.doc.length > 6000000) {
+    if (document && document.doc.length > 6000000) {
       document.url = await cacheGateway.getUrl(metadata.id);
     }
     return document;


### PR DESCRIPTION
It would throw an error otherwise for some files, cause rtf converter wouldn't know how to handle some files. This way it at least lets user download the doc