### PR TITLE
Add Makefile and Readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: setup
+setup:
+	npm i && pushd api && npm install && popd && pushd authorizer && npm install && popd
+
+.PHONY: test
+test: 
+	pushd api && npm run test-coverage && popd
+
+.PHONY: lint
+lint:
+	./node_modules/.bin/eslint .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# W2 Documents API
+
+## Table of Contents
+
+- [Documentation](#documentation)
+- [Dependencies](#dependencies)
+- [Development environment](#development-environment)
+
+## Documentation
+The W2 Documents API consits of 3 node projects:
+- The `/API` that handles the connection to W2 server and converts documents. 
+- `/authorizer`
+- The root project handles deployment using [serverless](https://serverless.com/).
+
+## Development environment
+
+1. Copy `.env.example` to `.env` and fill in the secrets
+2. Run `make setup`
+3. Run `make test` to run all the tests
+4. Run `make lint` to run the linter
+
+See `Makefile` for the steps involved in building and running the app.
+
+
+


### PR DESCRIPTION
### Context
There is no README or any sort of documentation for this repo that makes it challenging for new devs to quickly understand and add to this project. 

### Changes proposed in this pull request
- Add `Makefile` to help set up local dev environment
- Add `Readme` to describe the service and dependencies

### Guidance to review
This is a first slice of tackling the documentation of this repo, the README is quite "bare" at this point but I hope it helps to start the ball rolling. Is there anything essential you would add to the README?  
