### PR TITLE
Update /documents/:id/view endpoint to return HTML

### DIFF
--- a/api/lib/fileConverter/Rtf.js
+++ b/api/lib/fileConverter/Rtf.js
@@ -1,9 +1,17 @@
-const util = require('util');
-const rtfToHTML = require('@iarna/rtf-to-html');
-const convertRtf = util.promisify(rtfToHTML.fromString);
+const request = require('request-promise');
 const { MimeType } = require('@lib/Constants');
 
 module.exports = async function(doc) {
-  const converted = await convertRtf(doc);
+  const requestOptions = {
+    body: doc,
+    headers: {
+      'Content-Type': 'application/rtf'
+    },
+    method: 'POST',
+    uri: process.env.RTF_TO_HTML_URL
+  };
+
+  const converted = await request.post(requestOptions);
+
   return { mimeType: MimeType.Html, doc: converted };
 };

--- a/api/lib/fileConverter/index.js
+++ b/api/lib/fileConverter/index.js
@@ -7,8 +7,7 @@ const passthrough = extension => {
 };
 
 const converters = {
-  // rtf: require('./Rtf'), todo: rtf to html is never going to work, solution needs investigation.
-  rtf: passthrough('rtf'),
+  rtf: require('./Rtf'),
   xml: require('./Xml'),
   msg: require('./Msg'),
   pdf: passthrough('pdf'),

--- a/serverless.yml
+++ b/serverless.yml
@@ -43,6 +43,7 @@ functions:
               - '*'
     environment:
       URL_PREFIX: 'uhw'
+      RTF_TO_HTML_URL: ${ssm:/uhw-document-api/production/RTF_TO_HTML_URL}
       S3_BUCKET_NAME: ${ssm:/uhw-document-api/production/S3_BUCKET_NAME}
       W2_DB_URL: ${ssm:/uhw-document-api/production/W2_DB_URL}
       W2_IMAGE_SERVER_URL: ${ssm:/uhw-document-api/production/W2_IMAGE_SERVER_URL}
@@ -70,6 +71,7 @@ functions:
               - '*'
     environment:
       URL_PREFIX: 'hncomino'
+      RTF_TO_HTML_URL: ${ssm:/hncomino-document-api/production/RTF_TO_HTML_URL}
       S3_BUCKET_NAME: ${ssm:/hncomino-document-api/production/S3_BUCKET_NAME}
       W2_DB_URL: ${ssm:/hncomino-document-api/production/W2_DB_URL}
       W2_IMAGE_SERVER_URL: ${ssm:/hncomino-document-api/production/W2_IMAGE_SERVER_URL}


### PR DESCRIPTION
This endpoint transforms an RTF document into an HTML document via a separate 'RTF to HTML' API.