### PR TITLE
Update configuration of routes/middleware to use Sentry

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,15 @@
 /hncomino-document-api/production/W2_DB_URL=
 /hncomino-document-api/production/S3_BUCKET_NAME=
 /hncomino-document-api/production/RTF_TO_HTML_URL=
+
+/uhw-document-api/dev/W2_IMAGE_SERVER_URL=
+/uhw-document-api/dev/W2_DB_URL=
+/uhw-document-api/dev/S3_BUCKET_NAME=
+/hncomino-document-api/dev/W2_IMAGE_SERVER_URL=
+/hncomino-document-api/dev/W2_DB_URL=
+/hncomino-document-api/dev/S3_BUCKET_NAME=
+/hncomino-document-api/dev/RTF_TO_HTML_URL=
+
 /uhw-document-api/SENTRY_DSN=
 /hncomino-document-api/SENTRY_DSN=
 /common/hackney-jwt-secret=

--- a/api/lib/Dependencies.js
+++ b/api/lib/Dependencies.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const AWS = require('aws-sdk');
+const SqlServerConnection = require('@lib/SqlServerConnection');
+
+const { loadTemplates } = require('@lib/Utils');
+const templates = loadTemplates(path.join(__dirname, 'templates'));
+
+const imageServerGateway = require('@lib/gateways/ImageServerGateway')({
+  imageServerUrl: process.env.W2_IMAGE_SERVER_URL
+});
+
+const useCaseOptions = {
+  cacheGateway: require('@lib/gateways/S3Gateway')({
+    s3: new AWS.S3()
+  }),
+  dbGateway: require('@lib/gateways/W2Gateway')({
+    dbConnection: new SqlServerConnection({
+      dbUrl: process.env.W2_DB_URL
+    })
+  }),
+  documentHandlers: require('@lib/documentHandlers')({
+    emailTemplate: templates.emailTemplate,
+    imageServerGateway
+  }),
+  imageServerGateway
+};
+
+const {
+  getCustomerDocuments,
+  getDocumentMetadata,
+  getConvertedDocument,
+  getOriginalDocument,
+  getAttachment
+} = require('@lib/use-cases')(useCaseOptions);
+
+module.exports = {
+  getCustomerDocuments,
+  getDocumentMetadata,
+  getConvertedDocument,
+  getOriginalDocument,
+  getAttachment,
+  templates
+};

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,6 @@
     "@freiraum/msgreader": "github:bjpirt/msgreader",
     "@iarna/rtf-to-html": "^1.1.0",
     "@sentry/node": "^5.12.2",
-    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "handlebars": "^4.6.0",
     "mime-types": "^2.1.26",

--- a/authorizer/index.js
+++ b/authorizer/index.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const Sentry = require('@sentry/node');
 const jwt = require('jsonwebtoken');
 const cookie = require('cookie');

--- a/authorizer/package.json
+++ b/authorizer/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "dependencies": {
     "cookie": "^0.4.0",
-    "dotenv": "^8.2.0",
     "jsonwebtoken": "^8.5.1",
     "@sentry/node": "^5.12.2"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -429,9 +429,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "decompress": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
       "requires": {
         "decompress-tar": "^4.0.0",
@@ -4160,9 +4160,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {
@@ -4176,12 +4176,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "moment": {
@@ -4841,9 +4841,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "strip-json-comments": {
@@ -5348,9 +5348,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "mute-stream": {
@@ -6229,9 +6229,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "ms": {
@@ -6526,9 +6526,9 @@
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
+      "integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",


### PR DESCRIPTION
Sentry was not reporting errors due to incorrect configuration of routes/middleware in api/index.js

Changes:

- Moved local dependencies out of index.js for clarity
- Move sentry middleware below the routes
- Add error handling middleware for lambda logging and error response
- Update routes to pass errors on to error handling middleware
- Remove redundant dotenv package